### PR TITLE
Cognito 토큰 저장

### DIFF
--- a/src/pages/AuthCallbackPage.tsx
+++ b/src/pages/AuthCallbackPage.tsx
@@ -12,13 +12,10 @@ export default function AuthCallbackPage() {
     (async () => {
       try {
         const result = await handleAuthCallback();
-        if (!result) {
-          navigate('/', { replace: true });
-          return;
+        if (result) {
+          useAuthStore.getState().syncFromStorage();
         }
-        useAuthStore.getState().syncFromStorage();
-
-        navigate('/matches', { replace: true });
+        navigate('/', { replace: true });
       } catch (e: unknown) {
         const message = e instanceof Error ? e.message : '인증 처리 중 오류가 발생했습니다.';
         setError(message);

--- a/src/pages/AuthCallbackPage.tsx
+++ b/src/pages/AuthCallbackPage.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useState } from 'react';
+import { Box, Container, Paper, Typography, Button, CircularProgress, Stack } from '@mui/material';
+import { useNavigate } from 'react-router-dom';
+import { handleAuthCallback } from '../auth/callback';
+
+export default function AuthCallbackPage() {
+  const navigate = useNavigate();
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const result = await handleAuthCallback();
+        if (!result) {
+          navigate('/', { replace: true });
+          return;
+        }
+        navigate('/matches', { replace: true });
+      } catch (e: unknown) {
+        const message = e instanceof Error ? e.message : '인증 처리 중 오류가 발생했습니다.';
+        setError(message);
+      }
+    })();
+  }, [navigate]);
+
+  if (error) {
+    return (
+      <Container maxWidth="sm" sx={{ py: 8 }}>
+        <Paper sx={{ p: 4 }}>
+          <Stack spacing={2} alignItems="center">
+            <Typography variant="h6" fontWeight={700}>
+              로그인 실패
+            </Typography>
+            <Typography color="text.secondary">{error}</Typography>
+            <Stack direction="row" spacing={2}>
+              <Button variant="outlined" onClick={() => navigate('/', { replace: true })}>
+                홈으로
+              </Button>
+              <Button variant="contained" onClick={() => navigate(-1)}>
+                이전으로
+              </Button>
+            </Stack>
+          </Stack>
+        </Paper>
+      </Container>
+    );
+  }
+
+  return (
+    <Container maxWidth="sm" sx={{ py: 8 }}>
+      <Paper sx={{ p: 4 }}>
+        <Box
+          display="flex"
+          alignItems="center"
+          justifyContent="center"
+          flexDirection="column"
+          gap={2}
+        >
+          <CircularProgress />
+          <Typography color="text.secondary">로그인 처리 중…</Typography>
+        </Box>
+      </Paper>
+    </Container>
+  );
+}

--- a/src/pages/AuthCallbackPage.tsx
+++ b/src/pages/AuthCallbackPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { Box, Container, Paper, Typography, Button, CircularProgress, Stack } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
 import { handleAuthCallback } from '../auth/callback';
+import { useAuthStore } from '../store/useAuthStore';
 
 export default function AuthCallbackPage() {
   const navigate = useNavigate();
@@ -15,6 +16,8 @@ export default function AuthCallbackPage() {
           navigate('/', { replace: true });
           return;
         }
+        useAuthStore.getState().syncFromStorage();
+
         navigate('/matches', { replace: true });
       } catch (e: unknown) {
         const message = e instanceof Error ? e.message : '인증 처리 중 오류가 발생했습니다.';

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,25 +1,27 @@
-import { createBrowserRouter } from "react-router-dom"
-import AppLayout from "../components/AppLayout"
-import ProtectedRoute from "../components/ProtectedRoute"
-import HomePage from "../pages/HomePage"
-import SignupPage from "../pages/SignupPage"
-import LoginPage from "../pages/LoginPage"
-import ProfilePage from "../pages/ProfilePage"
-import MatchesPage from "../pages/MatchesPage"
-import MyMatchesPage from "../pages/MyMatchesPage"
-import CreateMatchPage from "../pages/CreateMatchPage"
-import NotFoundPage from "../pages/NotFoundPage"
+import { createBrowserRouter } from 'react-router-dom';
+import AppLayout from '../components/AppLayout';
+import ProtectedRoute from '../components/ProtectedRoute';
+import HomePage from '../pages/HomePage';
+import SignupPage from '../pages/SignupPage';
+import LoginPage from '../pages/LoginPage';
+import ProfilePage from '../pages/ProfilePage';
+import MatchesPage from '../pages/MatchesPage';
+import MyMatchesPage from '../pages/MyMatchesPage';
+import CreateMatchPage from '../pages/CreateMatchPage';
+import NotFoundPage from '../pages/NotFoundPage';
+import AuthCallbackPage from '../pages/AuthCallbackPage';
 
 export const router = createBrowserRouter([
   {
-    path: "/",
+    path: '/',
     element: <AppLayout />,
     children: [
       { index: true, element: <HomePage /> },
-      { path: "signup", element: <SignupPage /> },
-      { path: "login", element: <LoginPage /> },
+      { path: 'signup', element: <SignupPage /> },
+      { path: 'login', element: <LoginPage /> },
+      { path: 'auth/callback', element: <AuthCallbackPage /> },
       {
-        path: "profile",
+        path: 'profile',
         element: (
           <ProtectedRoute>
             <ProfilePage />
@@ -27,7 +29,7 @@ export const router = createBrowserRouter([
         ),
       },
       {
-        path: "matches",
+        path: 'matches',
         element: (
           <ProtectedRoute>
             <MatchesPage />
@@ -35,7 +37,7 @@ export const router = createBrowserRouter([
         ),
       },
       {
-        path: "matches/mine",
+        path: 'matches/mine',
         element: (
           <ProtectedRoute>
             <MyMatchesPage />
@@ -43,14 +45,14 @@ export const router = createBrowserRouter([
         ),
       },
       {
-        path: "admin/matches/new",
+        path: 'admin/matches/new',
         element: (
           <ProtectedRoute requiredRole="ADMIN">
             <CreateMatchPage />
           </ProtectedRoute>
         ),
       },
-      { path: "*", element: <NotFoundPage /> },
+      { path: '*', element: <NotFoundPage /> },
     ],
   },
-])
+]);


### PR DESCRIPTION
## 📌 PR 개요
Cognito 로그인 성공 후 콜백에서 code 추출 → /oauth2/token 교환 → 토큰 저장(localStorage)까지의 플로우를 구현하고, 저장된 토큰을 Zustand 스토어와 동기화하도록 반영

## 🔍 변경 사항
- src/pages/AuthCallbackPage.tsx
  - 콜백 페이지 추가: 로딩/에러 UI, 성공 시 /로 이동
- src/auth/callback.ts
  - code 파싱, 중복 교환 가드, /oauth2/token 교환, id_token/access_token/refresh_token 저장, history.replaceState로 code 제거
- src/routes/index.tsx
  - /auth/callback 라우트 등록(비보호)
- src/store/useAuthStore.ts
  - tokens 상태(idToken, accessToken, refreshToken) 추가
  - syncFromStorage, setTokens, clearTokens 액션 추가
  - logout 시 토큰/상태 정리

## 🧪 테스트 방법
1. 로그인 완료 → localStorage에 id_token, access_token(옵션: refresh_token) 저장 확인
2. 자동으로 / 로 이동 및 보호 라우트 접근 가능 확인

## ✅ 체크리스트
- [x] 코드가 정상적으로 동작함
- [x] 기존 기능에 문제가 없음
- [x] 코드 컨벤션(Prettier/ESLint, Checkstyle 등)을 통과함
- [x] 필요 시 문서 업데이트 완료
- [x] 관련 이슈에 연결함

## 📎 참고 이슈
Ref: #14 
