### PR TITLE
로그인 직후 유저 정보 추가/수정

### DIFF
--- a/src/api/userApi.ts
+++ b/src/api/userApi.ts
@@ -1,9 +1,11 @@
 import { api } from './axiosInstance';
 import type { User } from '../types';
 
-// API: GET /api/users/me
-// (Authorization: Bearer <access_token>)
-export async function fetchMyProfile(): Promise<User> {
-  const { data } = await api.get<User>('/api/users/me');
+export async function postUserMe(): Promise<void> {
+  await api.post('/user/me', null);
+}
+
+export async function getMyProfile(): Promise<User> {
+  const { data } = await api.get<User>('/user/me');
   return data;
 }

--- a/src/api/userApi.ts
+++ b/src/api/userApi.ts
@@ -2,10 +2,10 @@ import { api } from './axiosInstance';
 import type { User } from '../types';
 
 export async function postUserMe(): Promise<void> {
-  await api.post('/user/me', null);
+  await api.post('users/me', null);
 }
 
 export async function getMyProfile(): Promise<User> {
-  const { data } = await api.get<User>('/user/me');
+  const { data } = await api.get<User>('users/me');
   return data;
 }

--- a/src/auth/callback.ts
+++ b/src/auth/callback.ts
@@ -57,8 +57,8 @@ export async function handleAuthCallback(): Promise<TokenResponse | null> {
 
   try {
     await postUserMe();
-    const me = await getMyProfile();
-    useAuthStore.getState().setUser(me);
+    // const me = await getMyProfile();
+    // useAuthStore.getState().setUser(me);
   } catch (e) {
     console.error('[callback] user sync failed', e);
   }

--- a/src/auth/callback.ts
+++ b/src/auth/callback.ts
@@ -57,8 +57,8 @@ export async function handleAuthCallback(): Promise<TokenResponse | null> {
 
   try {
     await postUserMe();
-    // const me = await getMyProfile();
-    // useAuthStore.getState().setUser(me);
+    const me = await getMyProfile();
+    useAuthStore.getState().setUser(me);
   } catch (e) {
     console.error('[callback] user sync failed', e);
   }

--- a/src/auth/config.ts
+++ b/src/auth/config.ts
@@ -17,5 +17,5 @@ export const COGNITO: CognitoConfig = {
   hostedUiDomain: requireEnv('VITE_COGNITO_DOMAIN'),
   clientId: requireEnv('VITE_COGNITO_CLIENT_ID'),
   redirectUri: requireEnv('VITE_COGNITO_REDIRECT_URI'),
-  scopes: ['openid', 'email'],
+  scopes: ['openid', 'email', 'profile'],
 };

--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -24,6 +24,9 @@ interface AuthState {
   setTokens: (tokens: Tokens) => void;
   syncFromStorage: () => void;
   clearTokens: () => void;
+
+  // [추가] /user/me 응답을 전역에 반영하기 위한 액션
+  setUser: (_user: User | null) => void; // ← [추가]
 }
 
 // Mock users (기존 유지)
@@ -96,6 +99,11 @@ export const useAuthStore = create<AuthState>((set, get) => ({
 
   // 추가: 교환 결과를 직접 세팅하고 싶을 때 사용 가능
   setTokens: (tokens: Tokens) => {
+    // [수정] 새로고침 유지 위해 로컬스토리지에도 반영
+    localStorage.setItem('id_token', tokens.idToken ?? '');
+    localStorage.setItem('access_token', tokens.accessToken ?? '');
+    localStorage.setItem('refresh_token', tokens.refreshToken ?? '');
+
     set({
       tokens,
       isAuthenticated: Boolean(tokens.accessToken),
@@ -123,6 +131,9 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       isAuthenticated: false,
     });
   },
+
+  // [추가] /user/me 결과 반영
+  setUser: (_user) => set({ user: _user }), // ← [추가]
 }));
 
 // 기존 유지


### PR DESCRIPTION
## 📌 PR 개요
* API 경로 정규화 및 Authorization 헤더 누락 문제 수정
* `/api/users/me` POST 요청 시 토큰 정상 부착 및 응답 확인

## 🔍 변경 사항
* `axiosInstance`에서 `baseURL` 경로 비교 로직 수정 → `diff-path-prefix`로 인한 토큰 누락 방지
* 토큰 자동 부착이 필요한 API 호출에서 Authorization 헤더 정상 추가
* DEBUG 모드에서 요청/응답 로깅 개선

## 🧪 테스트 방법
1. 로그인 후 로컬스토리지의 access\_token이 존재하는 상태에서 `/api/users/me` POST 호출
2. 요청 헤더에 Authorization: Bearer {token} 포함 여부 확인
3. 응답이 정상적으로 500 또는 API 구현 상태에 따른 코드로 반환되는지 확인

## ✅ 체크리스트
* [x] 코드가 정상적으로 동작함
* [x] 기존 기능에 문제가 없음
* [x] 코드 컨벤션(Prettier/ESLint, Checkstyle 등)을 통과함
* [x] 필요 시 문서 업데이트 완료
* [x] 관련 이슈에 연결함

## 📎 참고 이슈

Ref: #24 

