### PR TITLE
🐛 fix: 로그아웃 후 사용하지 않는 /iogin 페이지로 리다이렉트 되지 않도록 수정

### DIFF
--- a/src/components/RouteGuards.tsx
+++ b/src/components/RouteGuards.tsx
@@ -3,6 +3,7 @@ import type { UserRole } from '../types/index';
 import { useEffect, useState } from 'react';
 import { Navigate, useLocation } from 'react-router-dom';
 import { useAuthStore } from '../store/useAuthStore';
+import { goLogin } from '../auth/hostedUi';
 
 // 공통 Props 타입
 interface RouteGuardProps {
@@ -33,7 +34,13 @@ export const ProtectedRoute = ({ children }: RouteGuardProps) => {
   // 로그인하지 않았다면 로그인 페이지로 리다이렉트
   // state에 현재 위치를 저장해서 로그인 후 다시 돌아올 수 있게 함
   if (!isAuthenticated) {
-    return <Navigate to="/login" state={{ from: location }} replace />;
+    // 홈 경로일 때는 가드 작동하지 않음
+    if (location.pathname === '/') {
+      return <>{children}</>;
+    }
+    // 다른 보호된 페이지일 때만 Cognito 로그인 UI로 리다이렉트
+    goLogin();
+    return null;
   }
 
   // 로그인했다면 원래 보려던 페이지 표시
@@ -56,7 +63,13 @@ export const RoleGuard = ({ children, requiredRole, fallbackPath = '/' }: RoleGu
 
   // 로그인하지 않았다면 로그인 페이지로
   if (!isAuthenticated) {
-    return <Navigate to="/login" state={{ from: location }} replace />;
+    // 홈 경로일 때는 가드 작동하지 않음
+    if (location.pathname === '/') {
+      return <>{children}</>;
+    }
+    // 다른 보호된 페이지일 때만 Cognito 로그인 UI로 리다이렉트
+    goLogin();
+    return null;
   }
 
   // 로그인했지만 권한이 없다면 fallback 경로로


### PR DESCRIPTION
## 📌 PR 개요
<!-- 이 PR이 무엇을 하는지 간단히 설명해주세요 -->
- 내 매칭 또는 프로필 제외 페이지에서 로그아웃 후 사용하지 않는 `login` 페이지로 이동하던 내용 수정

## 🔍 변경 사항
<!-- 주요 변경 사항을 bullet point로 작성해주세요 -->
- `RouteGuards.tsx` 파일에 `ProtectedRoute`와 `RoleGuard` 에서 `Navigate to="/login"` 삭제

## 🧪 테스트 방법
<!-- 변경 사항이 제대로 작동하는지 테스트하는 방법을 작성해주세요 -->
1. 로그인 상태에서 프로필 페이지(/profile) 또는 내 매칭 페이지(/matches/me)로 이동
2. 로그아웃 버튼 클릭

## ✅ 체크리스트
- [x] 코드가 정상적으로 동작함
- [x] 기존 기능에 문제가 없음
- [x] 코드 컨벤션(Prettier/ESLint, Checkstyle 등)을 통과함
- [ ] 필요 시 문서 업데이트 완료
- [ ] 관련 이슈에 연결함

## 📎 참고 이슈
<!-- 관련된 이슈 번호를 연결해주세요 (예: #123) -->
Ref: #
