### PR TITLE
Feature/41 docs readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,175 @@
 # next-kickytime-front
 
-React-based frontend for a futsal match-making platform integrated with AWS Cognito authentication, providing match participation and management UI, deployed via S3 &amp; CloudFront.
+> Kickytime 프론트엔드 – React(리액트) + Vite(바이트) + TypeScript(타입스크립트) 기반 SPA. AWS Cognito 인증 연동, 백엔드 API 호출, S3 + CloudFront 배포.
+
+- **프로젝트명**: Kickytime
+- **프로젝트 기간**: 2025-08-01 \~ 2025-08-14
+
+---
+
+## 팀원
+
+| 이름   | GitHub                                                                 |
+| ------ | ---------------------------------------------------------------------- |
+| 박민지 | [https://github.com/Mminzy22](https://github.com/Mminzy22)             |
+| 하영현 | [https://github.com/deepInTheWoodz](https://github.com/deepInTheWoodz) |
+| 이혜민 | [https://github.com/hyeminleeee](https://github.com/hyeminleeee)       |
+| 구태연 | [https://github.com/taeyeon119](https://github.com/taeyeon119)         |
+| 임정우 | [https://github.com/imjwoo](https://github.com/imjwoo)                 |
+
+---
+
+[![Docs: Wiki](https://img.shields.io/badge/docs-Wiki-0366d6)](../../wiki)
+
+> 자세한 운영/가이드는 GitHub **Wiki**를 참고하세요.
+
+### 📚 Wiki 빠른 링크
+
+- [Home](../../wiki)
+- [API 문서](../../wiki/API-문서)
+- [브랜치 전략](../../wiki/브랜치-전략)
+- [버전 관리 전략](../../wiki/버전-관리-전략)
+- [이슈 템플릿 가이드](../../wiki/이슈-템플릿-가이드)
+- [커밋 메시지 규칙](../../wiki/커밋-메시지-규칙)
+- [코드 스타일 자동화 설정](../../wiki/코드-스타일-자동화-설정)
+- [풀리퀘스트 템플릿](../../wiki/풀리퀘스트-템플릿)
+
+---
+
+## TL;DR
+
+```bash
+# 요구사항: Node.js(노드) 22+, npm(엔피엠)
+cp .env.example .env                 # 환경 변수 채우기
+npm ci                               # 의존성 설치
+npm run dev                          # http://localhost:5173
+
+# 프로덕션 빌드
+npm run build                        # dist/ 산출물 생성
+npm run preview                      # 로컬 미리보기(배포 에뮬)
+```
+
+---
+
+## 1) 개요(Overview)
+
+- **목표**: 관리자가 개설한 풋살 매칭 정보를 사용자에게 제공하고, 로그인 후 **참여/취소**가 가능한 UI 제공
+- **인증**: AWS Cognito Hosted UI → Access Token 발급 → 백엔드에 `Authorization: Bearer <token>` 전달
+- **라우팅**: React Router(리액트 라우터) 기반 SPA, `/callback`에서 인증 처리
+
+---
+
+## 2) 기술 스택(Tech Stack)
+
+- **프레임워크**: React, Vite, TypeScript
+- **상태 관리**: Zustand
+- **UI**: MUI
+- **품질**: ESLint(이에스린트), Prettier(프리티어), Husky(허스키) + lint-staged(린트-스테이지드)
+
+---
+
+## 3) 환경 변수(Environment Variables)
+
+Vite는 **`VITE_` 접두사**가 붙은 변수만 클라이언트에 노출됩니다.
+
+`.env.example` (예시)
+
+```env
+# API 엔드포인트
+VITE_API_BASE_URL=http://localhost:8080/api/
+
+# App
+VITE_APP_NAME=Kickytime
+VITE_APP_VERSION=1.0.0
+
+# Feature Flags
+VITE_USE_MOCK_DATA=false
+VITE_DEBUG_MODE=true
+
+# Cognito 설정
+VITE_COGNITO_DOMAIN=your-domain.auth.ap-northeast-2.amazoncognito.com
+VITE_COGNITO_CLIENT_ID=YOUR_CLIENT_ID
+VITE_REDIRECT_URI=http://localhost:5173/callback
+```
+
+**주의 사항**
+
+- 값은 배포 환경별로 `.env.production`, `.env.development` 등에 분리하세요.
+- 민감 정보는 리포에 커밋하지 않습니다(예: GitHub Actions 시크릿 사용).
+
+---
+
+## 4) 실행/빌드/검사(Commands)
+
+```bash
+npm ci                # 의존성 설치
+npm run dev           # 개발 서버(Hot Reload)
+npm run build         # 프로덕션 빌드(dist/)
+npm run preview       # 빌드 결과 미리보기
+npm run lint          # ESLint 검사
+npm run lint:fix      # ESLint 자동 고침
+npm run format        # Prettier 포맷
+npm run format:check  # 포맷 체크
+```
+
+---
+
+## 5) 인증 흐름(Auth Flow)
+
+1. 사용자가 **Cognito Hosted UI**로 이동해 로그인/회원가입
+2. 로그인 성공 → **Access Token** 등 토큰이 리다이렉트 URI(`/callback`)로 전달
+3. 프론트엔드에서 토큰을 저장(메모리/스토리지)
+4. API 호출 시 `Authorization: Bearer <token>` 헤더 첨부
+
+토큰 저장 방식과 만료 처리(리프레시 OR 재로그인)는 보안 정책에 맞춰 선택합니다.
+
+---
+
+## 6) API 연동(요약)
+
+- 기본 베이스 URL: `VITE_API_BASE_URL`
+- 주요 엔드포인트(백엔드 README/위키 참조)
+  - `GET /matches`, `POST /matches/{id}/participants`, ...
+  - `GET /users/me`
+
+자세히 보기: [API 문서](../../wiki/API-문서)
+
+---
+
+## 7) 배포(Deployment)
+
+- **타깃**: S3 정적 호스팅 + CloudFront CDN 배포
+- **캐시/무효화**: 정적 자산 캐시, 배포 후 **CloudFront Invalidation** 수행
+
+---
+
+## 8) 품질/자동화(Quality)
+
+- **Husky** pre-commit 훅에서 `lint-staged`로 변경 파일만 ESLint/Prettier 실행
+- PR 시 GitHub Actions에서 **포맷/린트/타입 체크** 실패 시 머지 불가
+
+`.husky/pre-commit` 예시
+
+```sh
+#!/usr/bin/env sh
+. "$(dirname "$0")/_/husky.sh"
+
+npx lint-staged
+```
+
+---
+
+## 9) 개발 규칙 & 협업 가이드
+
+- **브랜치 전략**: `main`, `develop`, `feature/*`, `hotfix/*` (보호 브랜치, PR 필수)
+- **커밋 컨벤션**: Conventional Commits + Gitmoji
+- **코드 스타일**: ESLint/Prettier, import 순서/unused 검사
+- **PR/이슈 템플릿**: Wiki 제공 템플릿 사용
+
+자세히 보기:
+
+- [커밋 메시지 규칙](../../wiki/커밋-메시지-규칙)
+- [브랜치 전략](../../wiki/브랜치-전략)
+- [이슈 템플릿 가이드](../../wiki/이슈-템플릿-가이드)
+- [풀리퀘스트 템플릿](../../wiki/풀리퀘스트-템플릿)
+- [코드 스타일 자동화 설정](../../wiki/코드-스타일-자동화-설정)

--- a/README.md
+++ b/README.md
@@ -19,20 +19,11 @@
 
 ---
 
-[![Docs: Wiki](https://img.shields.io/badge/docs-Wiki-0366d6)](../../wiki)
+[![Docs: Wiki](https://img.shields.io/badge/docs-Wiki-0366d6)](https://github.com/next-engineer/next-kickytime-front/wiki)
 
 > 자세한 운영/가이드는 GitHub **Wiki**를 참고하세요.
 
-### 📚 Wiki 빠른 링크
-
-- [Home](../../wiki)
-- [API 문서](../../wiki/API-문서)
-- [브랜치 전략](../../wiki/브랜치-전략)
-- [버전 관리 전략](../../wiki/버전-관리-전략)
-- [이슈 템플릿 가이드](../../wiki/이슈-템플릿-가이드)
-- [커밋 메시지 규칙](../../wiki/커밋-메시지-규칙)
-- [코드 스타일 자동화 설정](../../wiki/코드-스타일-자동화-설정)
-- [풀리퀘스트 템플릿](../../wiki/풀리퀘스트-템플릿)
+### [📚 Wiki 빠른 링크](https://github.com/next-engineer/next-kickytime-front/wiki)
 
 ---
 
@@ -132,7 +123,7 @@ npm run format:check  # 포맷 체크
   - `GET /matches`, `POST /matches/{id}/participants`, ...
   - `GET /users/me`
 
-자세히 보기: [API 문서](../../wiki/API-문서)
+자세히 보기: [API 문서](https://github.com/next-engineer/next-kickytime-front/wiki/API-문서)
 
 ---
 
@@ -168,8 +159,8 @@ npx lint-staged
 
 자세히 보기:
 
-- [커밋 메시지 규칙](../../wiki/커밋-메시지-규칙)
-- [브랜치 전략](../../wiki/브랜치-전략)
-- [이슈 템플릿 가이드](../../wiki/이슈-템플릿-가이드)
-- [풀리퀘스트 템플릿](../../wiki/풀리퀘스트-템플릿)
-- [코드 스타일 자동화 설정](../../wiki/코드-스타일-자동화-설정)
+- [커밋 메시지 규칙](https://github.com/next-engineer/next-kickytime-front/wiki/커밋-메시지-규칙)
+- [브랜치 전략](https://github.com/next-engineer/next-kickytime-front/wiki/브랜치-전략)
+- [이슈 템플릿 가이드](https://github.com/next-engineer/next-kickytime-front/wiki/이슈-템플릿-가이드)
+- [풀리퀘스트 템플릿](https://github.com/next-engineer/next-kickytime-front/wiki/풀리퀘스트-템플릿)
+- [코드 스타일 자동화 설정](https://github.com/next-engineer/next-kickytime-front/wiki/코드-스타일-자동화-설정)


### PR DESCRIPTION
## 📌 PR 개요
<!-- 이 PR이 무엇을 하는지 간단히 설명해주세요 -->
- 프론트엔드 리포지토리의 README.md를 전면 개정했습니다.
- 팀원 표, Wiki 링크, TL;DR, 기술 스택, 환경 변수(.env.example), 실행/빌드/검사 스크립트,
  인증 흐름, API 연동 요약, 배포와 품질 자동화, 협업 가이드를 추가·정리했습니다.

## 🔍 변경 사항
<!-- 주요 변경 사항을 bullet point로 작성해주세요 -->
- docs: 상단 소개 및 프로젝트 기간 명시
- docs: Wiki 배지/빠른 링크(리포 전용 위키 절대경로) 추가
- docs: **TL;DR** 섹션 신설 (Node.js 22+, `npm ci`, `npm run dev/build/preview`)
- docs: **기술 스택** 업데이트 (React/Vite/TS, Zustand, MUI, ESLint/Prettier/Husky)
- docs: **환경 변수** 섹션 정리 (`VITE_` 접두사, `.env.example` 추가값 포함)
- docs: **실행/빌드/검사** 커맨드 표준화 (`lint`, `lint:fix`, `format`, `format:check`)
- docs: **인증 흐름** (Cognito Hosted UI → `/callback` → 토큰 저장 → Authorization 헤더)
- docs: **API 연동 요약** 및 백엔드 엔드포인트 참조 안내
- docs: **배포** (S3 + CloudFront, Invalidation 언급)
- docs: **품질/자동화** (Husky + lint-staged pre-commit 예시 포함)
- docs: **협업 가이드** (브랜치 전략/커밋 컨벤션/템플릿 링크)

## 🧪 테스트 방법
<!-- 변경 사항이 제대로 작동하는지 테스트하는 방법을 작성해주세요 -->
1. **마크다운 렌더링 확인**
   - GitHub에서 README가 표/배지/코드블록 포함하여 정상 렌더링되는지 확인합니다.
2. **Wiki 링크 검증**
   - README 내 Wiki 링크(홈/브랜치 전략/커밋 규칙 등)가 모두 정상 이동하는지 확인합니다.
3. **TL;DR 실행**
   - Node.js 22+ 환경에서 `cp .env.example .env` → `npm ci` → `npm run dev` 수행 후
     `http://localhost:5173` 접속이 가능한지 확인합니다.
4. **환경 변수 반영**
   - `.env`의 `VITE_API_BASE_URL` 값을 변경하여 API 베이스 URL이 반영되는지 확인합니다.

## ✅ 체크리스트
- [x] 코드가 정상적으로 동작함
- [x] 기존 기능에 문제가 없음
- [x] 코드 컨벤션(Prettier/ESLint 등)을 통과함
- [x] 필요 시 문서 업데이트 완료(위키 링크/제목 변경 시 동기화)
- [x] 관련 이슈에 연결함

## 📎 참고 이슈
<!-- 관련된 이슈 번호를 연결해주세요 (예: #123) -->
Ref: #41 
