### PR TITLE
로그인 오류 수정 및 S3 + CloudFront 배포 반영

### DIFF
--- a/.github/workflows/s3cloudfront-cd.yml
+++ b/.github/workflows/s3cloudfront-cd.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   AWS_REGION: ap-northeast-2
-  S3_BUCKET: kickytime-bucket
+  S3_BUCKET: kickytime-frontend-205366594951
   CF_DIST_ID: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
   BUILD_DIR: build
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,6 @@ build
 .next
 coverage
 .github/
+
+# semantic-release가 생성/커밋하는 파일이라 포맷 검사 대상에서 제외
+CHANGELOG.md

--- a/src/auth/hostedUi.ts
+++ b/src/auth/hostedUi.ts
@@ -2,7 +2,8 @@ import { COGNITO } from './config';
 import { createPkce } from './pkce';
 
 function buildAuthorizeUrl(path: 'login' | 'signup', challenge: string) {
-  const u = new URL(`${COGNITO.hostedUiDomain}/${path}`);
+  const endpoint = path === 'login' ? 'oauth2/authorize' : 'signup';
+  const u = new URL(`${COGNITO.hostedUiDomain}/${endpoint}`);
   u.searchParams.set('response_type', 'code');
   u.searchParams.set('client_id', COGNITO.clientId);
   u.searchParams.set('redirect_uri', COGNITO.redirectUri);

--- a/src/pages/AuthCallbackPage.tsx
+++ b/src/pages/AuthCallbackPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Box, Container, Paper, Typography, Button, CircularProgress, Stack } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
 import { handleAuthCallback } from '../auth/callback';
@@ -7,19 +7,22 @@ import { useAuthStore } from '../store/useAuthStore';
 export default function AuthCallbackPage() {
   const navigate = useNavigate();
   const [error, setError] = useState<string | null>(null);
+  const callbackStarted = useRef(false);
 
   useEffect(() => {
+    if (callbackStarted.current) return;
+    callbackStarted.current = true;
+
     (async () => {
       try {
         const result = await handleAuthCallback();
         if (result) {
           useAuthStore.getState().syncFromStorage();
+          navigate('/', { replace: true });
         }
-        navigate('/', { replace: true });
       } catch (e: unknown) {
         const message = e instanceof Error ? e.message : '인증 처리 중 오류가 발생했습니다.';
         setError(message);
-        navigate('/login', { replace: true });
       }
     })();
   }, [navigate]);


### PR DESCRIPTION
## 📌 PR 개요
develop의 검증된 변경을 운영에 반영합니다.

## 🔍 변경 사항
- 로그인 엔드포인트 및 콜백 중복 실행 수정 (#51)
- S3 배포 버킷을 `kickytime-frontend-205366594951`로 변경

## 🧪 테스트 방법
1. 병합 후 `s3cloudfront-cd.yml` 실행 성공 확인
2. `https://d2hk3a4qv3wwww.cloudfront.net` 접속 → 로그인 → 경기 목록 조회

## ✅ 체크리스트
- [ ] 코드가 정상적으로 동작함
- [ ] 기존 기능에 문제가 없음
- [ ] 코드 컨벤션(Prettier/ESLint)을 통과함
- [ ] 관련 이슈에 연결함

## 📎 참고 이슈
Ref: #51