### PR TITLE
Prettier 포맷 검사에서 CHANGELOG.md 제외

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,6 @@ build
 .next
 coverage
 .github/
+
+# semantic-release가 생성/커밋하는 파일이라 포맷 검사 대상에서 제외
+CHANGELOG.md


### PR DESCRIPTION
## 📌 PR 개요
develop → main PR에서 Prettier 포맷 검사가 실패하는 문제를 해결합니다.

## 🔍 변경 사항
- `.prettierignore`에 `CHANGELOG.md` 추가

### 원인
- `CHANGELOG.md`는 `@semantic-release/changelog`가 생성하고
  `@semantic-release/git`이 main에 커밋하는 산출물입니다
- 릴리스 커밋 메시지에 `[skip ci]`가 포함되어 있어 생성 시점에 CI가 실행되지 않았고,
  포맷되지 않은 상태로 main에 남아 있었습니다
- develop과 feature 브랜치에는 이 파일이 없어 그동안 드러나지 않다가,
  main을 대상으로 하는 PR에서 CI가 병합 결과를 검사하면서 처음 실패했습니다

### 수동 포맷 대신 ignore를 선택한 이유
`prettier --write`로 한 번 고쳐도 다음 릴리스에서 파일이 다시 생성·커밋되므로
동일한 실패가 반복됩니다. 생성 파일은 포맷 검사 대상에서 제외하는 것이 맞습니다.
같은 이유로 `.github/`도 이미 제외되어 있습니다.

## 🧪 테스트 방법
1. main의 CHANGELOG.md를 로컬 작업 트리에 복사
   `git show origin/main:CHANGELOG.md > CHANGELOG.md`
2. `npm run format:check` → 통과 확인
3. 임시 파일 삭제 후 `npm run lint`, `npx tsc --noEmit` 통과 확인

로컬 검증 결과 3단계 모두 통과했습니다.

## ✅ 체크리스트
- [ ] 코드가 정상적으로 동작함
- [ ] 기존 기능에 문제가 없음
- [ ] 코드 컨벤션(Prettier/ESLint)을 통과함
- [ ] 필요 시 문서 업데이트 완료
- [ ] 관련 이슈에 연결함

## 📎 참고 이슈
Ref: -